### PR TITLE
fix secret reconciliation

### DIFF
--- a/pkg/controller/credstashsecret/credstashsecret_controller.go
+++ b/pkg/controller/credstashsecret/credstashsecret_controller.go
@@ -217,8 +217,8 @@ func (r *ReconcileCredstashSecret) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, err
 	}
 
-	// Secret is out of date with credstash data
-	if !reflect.DeepEqual(secret, found) {
+	// Secret data or type is out of date with kalamaja secret
+	if !reflect.DeepEqual(secret.Data, found.Data) || !reflect.DeepEqual(secret.Type, found.Type) {
 		reqLogger.Info(
 			"Updating Secret because contents have changed",
 			"Secret.Namespace",


### PR DESCRIPTION
Only secret Data and Type should be compared during reconciliation otherwise projected and existing secrets will never match due to metadata that contains timestamps and some other stuff that we don't really care about.