### PR TITLE
feat: push chart to helm repo

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -104,6 +104,7 @@ presubmits:
     max_concurrency: 1
     labels:
       preset-semantic-release: "true"
+      preset-ouzi-helm-push: "true"
     trigger: "(?m)semrelease-dryrun( please)?"
     rerun_command: "semrelease-dryrun"
     spec:
@@ -120,6 +121,7 @@ postsubmits:
     labels:
       preset-semantic-release: "true"
       preset-gcloud-testinfra-prow: "true"
+      preset-ouzi-helm-push: "true"
     clone_uri: "git@github.com:ouzi-dev/credstash-operator.git"
     decorate: true
     max_concurrency: 1

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,6 @@ ifneq ($(BINARY_VERSION),)
 	LDFLAGS += -X $(BASE_BUILD_PATH)/version.Version=${BINARY_VERSION}
 endif
 
-export PATH := ./bin:$(PATH)
-
 .PHONY: setup-lint
 setup-lint:
 	@echo "bootstrap lint..."
@@ -168,6 +166,10 @@ CHART_NAME ?= credstash-operator
 CHART_VERSION ?= 0.0.0
 CHART_PATH ?= deploy/helm
 CHART_DIST ?= $(CHART_PATH)/$(CHART_NAME)/dist
+HELM_PLUGIN_PUSH_URL := https://github.com/chartmuseum/helm-push
+HELM_PLUGIN_PUSH_VERSION := v0.8.1
+HELM_REPO_URL := https://charts.ouzi.io
+HELM_REPO_NAME := ouzi
 
 .PHONY: helm-clean
 helm-clean:
@@ -200,6 +202,15 @@ helm-package: helm-clean
 .PHONY: helm-lint
 helm-lint:
 	helm lint $(CHART_PATH)/$(CHART_NAME)
+
+.PHONY: helm-push-init
+helm-push-init:
+	@helm plugin install $(HELM_PLUGIN_PUSH_URL) --version $(HELM_PLUGIN_PUSH_VERSION) || echo "Plugin already installed - nothing to do"
+	@helm repo add $(HELM_REPO_NAME) $(HELM_REPO_URL)
+	@helm repo update
+
+helm-push: helm-push-init
+	@helm push $(CHART_DIST)/$(CHART_NAME)-$(CHART_VERSION).tgz $(HELM_REPO_NAME)
 
 .PHONY: semantic-release
 semantic-release:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,15 @@ helm upgrade --install credstash https://github.com/ouzi-dev/credstash-operator/
 ``` 
 Where ${VERSION} is the version you want to install
 
+#### Using the Ouzi helm repo
+```
+helm repo add ouzi https://charts.ouzi.io
+helm repo update
+helm upgrade --install credstash ouzi/credstash-operator \
+    --version ${VERSION}
+    -n credstash \
+    --set awsCredentials.secretName=aws-credentials
+```
 ### Multi-Tenancy
 
 The operator can monitor CRDs that have:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
       [
         "@semantic-release/exec",
         {
-          "prepareCmd": "make docker-push helm-package VERSION=v${nextRelease.version}"
+          "prepareCmd": "make docker-push helm-package helm-push VERSION=v${nextRelease.version}"
         }
       ],
       [


### PR DESCRIPTION
## Description
This change adds a push step to the semantic release process on merge to master. The step pushes the helm chart to the ouzi helm repo (https://charts.ouzi.io)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update