### PR TITLE
fix: use the correct make var to determine chart version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ helm-push-init:
 	@helm repo update
 
 helm-push: helm-push-init
-	@helm push $(CHART_DIST)/$(CHART_NAME)-$(CHART_VERSION).tgz $(HELM_REPO_NAME)
+	@helm push $(CHART_DIST)/$(CHART_NAME)-$(VERSION).tgz $(HELM_REPO_NAME)
 
 .PHONY: semantic-release
 semantic-release:


### PR DESCRIPTION
## Description

Fixes wrong variable usage when pushing helm chart

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update